### PR TITLE
Extend 'acessar' button to work with middle click

### DIFF
--- a/src/components/projects/ProjectsList.tsx
+++ b/src/components/projects/ProjectsList.tsx
@@ -126,6 +126,7 @@ function ProjectCard(props: ProjectProps) {
                       size="large"
                       variant="contained"
                       onClick={accessProjectRepo}
+                      onAuxClick={accessProjectRepo}
                     >
                       <b>acessar</b>
                     </Button>


### PR DESCRIPTION
Currently, the pink 'acessar' buttons don't react to a middle click, although I expected it to open the URL in a new tab (which it already does with a regular left click). This PR extends the behavior to the middle click using the `onAuxClick` property, added to React @ https://github.com/facebook/react/pull/11571