### PR TITLE
feat: justify text content in 'Regras e Princípios'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "globo-hacktoberfest",
-      "version": "0.1.0",
+      "version": "1.1.0",
       "license": "0BSD",
       "dependencies": {
         "@material-ui/core": "^4.11.4",
@@ -28,6 +28,7 @@
         "gatsby-plugin-web-font-loader": "^1.0.4",
         "gatsby-source-filesystem": "^3.12.0",
         "gatsby-transformer-sharp": "^3.4.0",
+        "json2mq": "^0.2.0",
         "prop-types": "^15.7.2",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
@@ -35,6 +36,7 @@
         "react-slick": "^0.28.1",
         "react-slideshow-image": "^3.4.6",
         "slick-carousel": "^1.8.1",
+        "string-convert": "^0.2.1",
         "yup": "^0.32.9"
       },
       "devDependencies": {
@@ -20685,6 +20687,11 @@
         }
       ]
     },
+    "node_modules/string-convert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+      "integrity": "sha1-aYLMMEn7tM2F+LJFaLnZvznu/5c="
+    },
     "node_modules/string-env-interpolation": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz",
@@ -39909,6 +39916,11 @@
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
+    },
+    "string-convert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+      "integrity": "sha1-aYLMMEn7tM2F+LJFaLnZvznu/5c="
     },
     "string-env-interpolation": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "gatsby-plugin-web-font-loader": "^1.0.4",
     "gatsby-source-filesystem": "^3.12.0",
     "gatsby-transformer-sharp": "^3.4.0",
+    "json2mq": "^0.2.0",
     "prop-types": "^15.7.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
@@ -31,6 +32,7 @@
     "react-slick": "^0.28.1",
     "react-slideshow-image": "^3.4.6",
     "slick-carousel": "^1.8.1",
+    "string-convert": "^0.2.1",
     "yup": "^0.32.9"
   },
   "devDependencies": {

--- a/src/pages/regras.tsx
+++ b/src/pages/regras.tsx
@@ -14,16 +14,16 @@ const Rule = (props: RuleProps) => {
       {props.title && <Spacing smart={{margin: "0px 0px 8px"}}>
         <Typography variant="h3" component="p" color="textPrimary" style={{fontWeight: 600}}> {props.title} </Typography>
       </Spacing> }
-      <Typography variant="h3" align="center" component="span" color="textPrimary"> {props.children} </Typography>
+      <Typography variant="h3" align="center" component="span" color="textPrimary" style={{display: "inline-flex"}}> {props.children} </Typography>
     </React.Fragment>
   )
 }
 
 const RuleBookPage = () => {
   return (
-    <Layout 
-      title="Regras e Princípios - Globo Hacktoberfest" 
-      description="Regras e Princípos - Globo Hacktoberfest" 
+    <Layout
+      title="Regras e Princípios - Globo Hacktoberfest"
+      description="Regras e Princípos - Globo Hacktoberfest"
       headerTitle="Regras e Princípios">
       <Spacing smart={{padding: "0px 40px"}}>
         <Grid container direction="column" justifyContent="center" alignItems="flex-start" alignContent="center">
@@ -34,20 +34,20 @@ const RuleBookPage = () => {
           </Spacing>
           <Spacing smart={{margin: "0px 0px 40px"}}>
             <Grid item  md={6}>
-              <Rule title="Todos são bem-vindos"> 
+              <Rule title="Todos são bem-vindos">
                 Os participantes do Hacktoberfest representaram 151 países e reuniu milhares de habilidades únicas. Damos as boas-vindas a todos que já fazem parte da comunidade de software de código aberto e todos que estão interessados em mergulhar nesse universo.
               </Rule>
             </Grid>
           </Spacing>
           <Spacing smart={{margin: "0px 0px 40px"}}>
             <Grid item md={6}>
-              <Rule title="A quantidade é divertida, a qualidade é a chave."> 
+              <Rule title="A quantidade é divertida, a qualidade é a chave.">
                 Participar do Hacktoberfest leva ao crescimento pessoal, oportunidades profissionais e construção de comunidade. No entanto, tudo começa com contribuições significativas para o software de código aberto.
               </Rule>
             </Grid>
           </Spacing>
           <Grid item md={6}>
-            <Rule title="Ação de curto prazo, impacto de longo prazo."> 
+            <Rule title="Ação de curto prazo, impacto de longo prazo.">
               Na comunidade de software de código aberto, estamos nos apoiando nos ombros daqueles que vieram antes de nós. Sua participação tem um efeito duradouro nas pessoas e na tecnologia, muito depois de outubro. Esta é uma viagem, não uma corrida.
             </Rule>
           </Grid>

--- a/src/pages/regras.tsx
+++ b/src/pages/regras.tsx
@@ -14,7 +14,7 @@ const Rule = (props: RuleProps) => {
       {props.title && <Spacing smart={{margin: "0px 0px 8px"}}>
         <Typography variant="h3" component="p" color="textPrimary" style={{fontWeight: 600}}> {props.title} </Typography>
       </Spacing> }
-      <Typography variant="h3" align="center" component="span" color="textPrimary" style={{display: "inline-flex"}}> {props.children} </Typography>
+      <Typography variant="h3" align="justify" component="span" color="textPrimary" style={{display: "inline-flex"}}> {props.children} </Typography>
     </React.Fragment>
   )
 }


### PR DESCRIPTION
Following [Typography/Props](https://mui.com/pt/api/typography/#props), I changed the align property from Typography to `.MuiTypography-alignJustify`

So, the text content is now justified, take a look:

| Not justified                                                                                                                            | Justified                                                                                                                       |
|------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
| ![hacktoberfest.globo.com_regras](https://user-images.githubusercontent.com/30991675/137800095-9c2fd196-e221-4938-b29e-a4525853fd00.png) | ![localhost_8000_regras](https://user-images.githubusercontent.com/30991675/137800224-c3def516-30cb-4c9a-840c-6ef48f724b65.png) |
