### PR TITLE
Text corrections in member area

### DIFF
--- a/src/components/forms/PersonalData.form.tsx
+++ b/src/components/forms/PersonalData.form.tsx
@@ -21,7 +21,7 @@ const validationSchema = () => Yup.object().shape({
             .string()
             .email("E-mail inválido")
             .required("Preenchimento do email obrigatório"),
-    githubUser: Yup.string().required("Preenchimento do github user"),
+    githubUser: Yup.string().required("Preenchimento do usuário Github obrigatório"),
 })
 
 

--- a/src/components/forms/Shipping.form.tsx
+++ b/src/components/forms/Shipping.form.tsx
@@ -29,7 +29,7 @@ const validationSchema = () => Yup.object().shape({
             .max(30, "Nome longo demais")
             .required("Preenchimento do nome é obrigatório"),
     city: Yup.string().required("Preenchimento da cidade é obrigatório"),
-    postalCode: Yup.string().required("Preenchmento do CEP é obrigatório"),
+    postalCode: Yup.string().required("Preenchimento do CEP é obrigatório"),
     state: Yup.string().required("Preenchimento do Estado é obrigatório"),
     address: Yup.string().required("Preenchimento da Rua é obrigatório")
 })


### PR DESCRIPTION
Text corrections in member area
- Translated user:  `github user` -> `usuário Github obrigatório`
- Fixed spelling: `Preenchmento` -> `Preenchimento`