### PR TITLE
Removing invalid color option in member registration

### DIFF
--- a/src/components/forms/Shipping.form.tsx
+++ b/src/components/forms/Shipping.form.tsx
@@ -204,7 +204,6 @@ const ShippingForm = (props: ShippingFormProps) => {
                                             <ColorizeIcon/>
                                         </InputAdornment>
                                 }}>
-                                <MenuItem disabled value={''}/>
                                 {
                                     colors.map((color, index) => (<MenuItem key={index} value={color}>{color}</MenuItem>))
                                 }


### PR DESCRIPTION
The current field looks like it was an unloaded color name.

before (current) | after |
------- | ----- |
![image](https://user-images.githubusercontent.com/5731176/139558500-1ecb4b38-2ce8-4212-9097-db44ee6fa4ea.png) | ![image](https://user-images.githubusercontent.com/5731176/139558501-2f18d3f0-4b77-47b0-bc62-be7e1bd327d1.png) |
