### PR TITLE
Update Homepage Title to "Globo Hacktoberfest"

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -125,7 +125,7 @@ const IndexPage = () => {
   // TODO: trazer o padding que ficava dentro do layout, pra ca, ai a tela ia ficar com background color sem fazer gambiarra
   return (
     <Layout
-      title="Início - Globo Hacktoberfest"
+      title="Globo Hacktoberfest"
     >
       <div className={classes.root}>
         {(user && !user?.email) && <EmailPopin user={user} />}


### PR DESCRIPTION
This pull request updates the homepage title to **Globo Hacktoberfest**. Currently, when sharing the homepage link https://hacktoberfest.globo.com/, it displays the title as _Início - Globo Hacktoberfest_. The goal of this change is to remove the "Início" prefix and ensure that the title appears correctly as _Globo Hacktoberfest_ when shared or previewed.