### PR TITLE
fix: disable GitHub user and ID fields.

### DIFF
--- a/src/components/forms/PersonalData.form.tsx
+++ b/src/components/forms/PersonalData.form.tsx
@@ -102,7 +102,7 @@ const PersonalDataForm = (props: PersonalDataFormProps) => {
                 helperText={formik.touched.githubUser && formik.errors.githubUser}
                 InputProps={{
                   startAdornment: <InputAdornment position="start">@</InputAdornment>,
-                  readOnly: true
+                  disabled: true
                 }}
               />
             </Grid>
@@ -114,7 +114,7 @@ const PersonalDataForm = (props: PersonalDataFormProps) => {
                 variant="outlined"
                 label="ID Github"
                 InputProps={{
-                  readOnly: true
+                  disabled: true
                 }}
               />
             </Grid>


### PR DESCRIPTION
This MR updates the GitHub user and ID fields from `readOnly` to `disabled`. The fields now visually match the disabled state and cannot be interacted with.

![image](https://github.com/user-attachments/assets/0993395a-d636-4204-96e4-e8a94d32f251)