### PR TITLE
Fix hero smart colors for desktop

### DIFF
--- a/src/components/hero/HeroSmart.tsx
+++ b/src/components/hero/HeroSmart.tsx
@@ -67,6 +67,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   progression: {
     border: '2px solid #fff',
+    background-color: '#05A6FF',
     display: 'flex',
     justifyContent: 'space-between',
     borderRadius: 8,
@@ -84,6 +85,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginTop: 40,
     marginBottom: 10,
     alignItems: 'flex-start',
+    color: '#000',
+    [theme.breakpoints.between("sm", "md")]: {
+      color: '#fff'
+    }
   },
   titleData: {
     fontSize: '7.5vw',


### PR DESCRIPTION
Antes:

<img width="957" height="1132" alt="image" src="https://github.com/user-attachments/assets/aaf881e1-211e-4664-974d-4fef56f0bd24" />

Depois:
<img width="966" height="1239" alt="image" src="https://github.com/user-attachments/assets/c7f98691-1a18-4b0c-8a63-801a2d84730d" />

