### PR TITLE
fix: horizontal scrool on smart, and some paddings normalization

### DIFF
--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -106,7 +106,7 @@ const FooterSmart = (props: FooterItemsProps) => {
       justifyContent="space-around"
       alignItems="flex-start"
     >
-      <Spacing smart={{ margin: "10px 32px 0" }}>
+      <Spacing smart={{ margin: "24px 32px 0" }}>
         <Grid item>
           <Image height="30" src="2025/globo.svg" />
         </Grid>
@@ -139,7 +139,7 @@ const FooterSmart = (props: FooterItemsProps) => {
           justifyContent="flex-end"
           alignItems="flex-end"
         >
-          <Grid item sm={12}>
+          <Grid item style={{ marginBottom: "9px" }} sm={12}>
             <ScrollTop />
           </Grid>
         </Grid>

--- a/src/components/rules/Rules.tsx
+++ b/src/components/rules/Rules.tsx
@@ -302,7 +302,7 @@ const RulesDesktop = (props: RulesProps) => {
 const RulesSmart = (props: RulesProps) => {
   const classes = useStyles()
   return (
-    <Spacing smart={{ margin: "0 auto 100px auto" }}>
+    <Spacing smart={{ margin: "60px auto 60px auto" }}>
       <div>
         <Grid container direction="column">
           <Grid item key={"como-participar"} className={classes.projectTitle}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -95,7 +95,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   projectItem: {
     width: "100%",
-    marginTop: "120px",
+    marginTop: "60px",
   },
   computer: {
     width: "165px",
@@ -109,6 +109,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   backgroundImage: {
     position: "absolute",
     zIndex: 1,
+    maxWidth: "100%",
     [theme.breakpoints.down("sm")]: {
       width: "240%",
       height: "auto",


### PR DESCRIPTION
Fix come-to-globo horizontal scroll issue.
In mobile device breakpoint, add padding for "Como participar" section, normalize margin between sections to 60px and add little margin to scroll to top button.